### PR TITLE
Fix issue with twitter deep linking redirection on mobile

### DIFF
--- a/src/authors.js
+++ b/src/authors.js
@@ -4,18 +4,18 @@ import steveschogerAvatar from './img/steveschoger.jpg'
 
 export const adamwathan = {
   name: 'Adam Wathan',
-  twitter: '@adamwathan',
+  twitter: 'adamwathan',
   avatar: adamwathanAvatar,
 }
 
 export const bradlc = {
   name: 'Brad Cornes',
-  twitter: '@bradlc',
+  twitter: 'bradlc',
   avatar: bradlcAvatar,
 }
 
 export const steveschoger = {
   name: 'Steve Schoger',
-  twitter: '@steveschoger',
+  twitter: 'steveschoger',
   avatar: steveschogerAvatar,
 }

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -73,7 +73,7 @@ export default function Post({ meta, children, posts }) {
                         href={`https://twitter.com/${author.twitter}`}
                         className="text-teal-500 hover:text-teal-600"
                       >
-                        {author.twitter}
+                        @{author.twitter}
                       </a>
                     </dd>
                   </dl>


### PR DESCRIPTION
The issue is that when you click on an author's Twitter URL on mobile, it does not deep link correctly with the Twitter app.
If you are on desktop, twitter.com strips the '@' character, and the binding works.
After removing the '@' from the URL it works on mobile too.