### PR TITLE
Fixing "Documentation" link in the header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -47,7 +47,7 @@ export default function Header() {
         </Link>
       </div>
       <div className="text-base leading-5">
-        <a href="https://tailwindcss.com" className="font-medium text-gray-500 hover:text-gray-700">
+        <a href="https://tailwindcss.com/docs" className="font-medium text-gray-500 hover:text-gray-700">
           Documentation &rarr;
         </a>
       </div>


### PR DESCRIPTION
Updating the "Documentation" link to point to the docs page instead of homepage