### PR TITLE
Fix site build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -90,7 +90,7 @@ module.exports = withBundleAnalyzer({
 
       config.entry = async () => {
         const entries = { ...(await originalEntry()) }
-        entries['./scripts/build-rss.js'] = './scripts/build-rss.js'
+        entries['scripts/build-rss'] = './scripts/build-rss.js'
         return entries
       }
     }


### PR DESCRIPTION
This PR fixes the `yarn build` script, specifically the `Cannot find module '../../webpack-runtime.js'` error when executing the `build-rss.js` script. The issue appears to have been introduced when upgrading to Next.js v11.